### PR TITLE
Correct documentation of SHCoeffs and TFCoeffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.log
 log.txt
 examples/*/*
+
+.idea/*

--- a/polaris/harmonics/shcoeffs.py
+++ b/polaris/harmonics/shcoeffs.py
@@ -13,14 +13,14 @@ G = np.load(os.path.join(os.path.dirname(__file__), 'gaunt_l4.npy'))
 
 class SHCoeffs:
     """An SHCoeffs object stores real spherical harmonic coefficients for even
-    bands. It provides methods for adding, multiplying, and plotting these
+    bands (ell coefficients). It provides methods for adding, multiplying, and plotting these
     coefficients.
 
     Inspired by a similar class in SHTOOLS https://shtools.github.io/SHTOOLS/
 
     Uses the following "lexicographic ordering" of the even spherical harmonics:
 
-    y_0^0, y_2^-2, y_2^0, y_2^2, y_4^-4, ...
+    y_0^0, y_2^-2, y_2^-1, y_2^0, y_2^1, y_2^2, y_4^-4, y_4^-3...
     """
 
     def __init__(self, coeffs):

--- a/polaris/harmonics/tfcoeffs.py
+++ b/polaris/harmonics/tfcoeffs.py
@@ -21,9 +21,9 @@ class TFCoeffs:
     second index corresponds to the spherical harmonics. We use the following
     "lexicographic ordering" of the harmonics:
 
-    z_0  y_0^0, z_0  y_2^-2, z_0  y_2^0, ...
-    z_-2 y_0^0, z_-2 y_2^-2, z_-2 y_2^0,
-    z_2  y_0^0, z_2  y_2^-2, z_2  y_2^0,
+    z_0  y_0^0, z_0  y_2^-2, z_0 y_2^-1, z_0  y_2^0, ...
+    z_-2 y_0^0, z_-2 y_2^-2, z_-2 y_2^-1, z_-2 y_2^0,
+    z_2  y_0^0, z_2  y_2^-2, z_2 y_2^-1, z_2  y_2^0,
     .
     .
     .


### PR DESCRIPTION
Corrects an error in the documentation. Docs said odd m SH coefficients were skipped, and the code uses all m SH coeffs. 

During my first implementation I thought we would only need the even ell coefficients (correct) and the even m coefficients (incorrect) and documented accordingly. It wasn't long afterwards that I realized all m coefficients are needed to complete rotationally invariant subspaces of L_2(S^2) and updated the code without updating the docstring. 

Many thanks to @jyuliu99 and @eguomin for this catch. 
